### PR TITLE
URL encodes path rather than query escaping it

### DIFF
--- a/dashing.go
+++ b/dashing.go
@@ -398,7 +398,8 @@ func autolink(target string) *html.Node {
 
 // newA creates a TOC anchor.
 func newA(name, etype string) *html.Node {
-	name = url.QueryEscape(name)
+	u := &url.URL{Path: name}
+	name = u.String()
 
 	target := fmt.Sprintf("//apple_ref/cpp/%s/%s", etype, name)
 	return &html.Node{


### PR DESCRIPTION
Query escaping turns spaces into `+` signs, which doesn’t look great in
Dash. URL-encoding the path replaces spaces with `%20`, which are
correctly interpreted by the Dash parser as spaces.