### PR TITLE
Add support for external fallback URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ The basic Dashing format looks like this:
     "name": "Dashing",
     "index":"index.html",
     "icon32x32": "icon.png",
+    "externalURL": "https://github.com/technosophos/dashing"
     "selectors": {
         "dt a": "Command",
         "title": "Package"
@@ -67,6 +68,7 @@ The basic Dashing format looks like this:
 - name: Name of the package
 - index: Default index file in the existing docs
 - icon32x32: a 32x32 pixel PNG icon
+- externalURL: the base URL of the docs
 - selectors: a map of selectors. There is a simple format and
   a more advanced format (see below for details).
 - ignore: a list of matches to be ignored (see below)

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ The basic Dashing format looks like this:
     "name": "Dashing",
     "index":"index.html",
     "icon32x32": "icon.png",
-    "externalURL": "https://github.com/technosophos/dashing"
+    "externalURL": "https://github.com/technosophos/dashing",
     "selectors": {
         "dt a": "Command",
         "title": "Package"

--- a/dashing.go
+++ b/dashing.go
@@ -39,7 +39,9 @@ const plist = `<?xml version="1.0" encoding="UTF-8"?>
 	<string>dashtoc</string>
 	<key>dashIndexFilePath</key>
 	<string>{{.Index}}</string>
-	<key>isJavaScriptEnabled</key><{{.AllowJS}}/>
+	<key>isJavaScriptEnabled</key><{{.AllowJS}}/>{{if .ExternalURL}}
+	<key>DashDocSetFallbackURL</key>
+	<string>{{.ExternalURL}}</string>{{end}}
 </dict>
 </plist>
 `
@@ -63,6 +65,8 @@ type Dashing struct {
 	// A 32x32 pixel PNG image.
 	Icon32x32 string `json:"icon32x32"`
 	AllowJS   bool   `json:"allowJS"`
+	// External URL for "Open Online Page"
+	ExternalURL string `json: "externalURL"`
 }
 
 // Transform is a description of what should be done with a selector.
@@ -269,10 +273,11 @@ func addPlist(name string, config *Dashing) {
 	}
 
 	tvars := map[string]string{
-		"Name":      name,
-		"FancyName": fancyName,
-		"Index":     config.Index,
-		"AllowJS":   aj,
+		"Name":        name,
+		"FancyName":   fancyName,
+		"Index":       config.Index,
+		"AllowJS":     aj,
+		"ExternalURL": config.ExternalURL,
 	}
 
 	err := t.Execute(&file, tvars)

--- a/examples/busybox/dashing.json
+++ b/examples/busybox/dashing.json
@@ -3,6 +3,7 @@
     "package":"busybox",
     "index":"BusyBox.html",
     "icon32x32":"busybox1.png",
+    "externalURL":"https://busybox.net/downloads/",
     "selectors": {
         "dt a": "Command",
         "title": {


### PR DESCRIPTION
This enables Dash's "Open Online Page" feature.