### PR TITLE
Add support for more selectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ The format of the selector value is:
 
 ```json
 "css selector": {
+      "requiretext": "require that the text matches a regexp. If not, this node is not considered as selected",
       "type": "Dash data type",
       "attr": "Use the value of the specified attribute instead of html node text as the basis for transformation",
       "regexp": "PCRE regular expression (no need to enclose in //)",

--- a/README.md
+++ b/README.md
@@ -141,7 +141,8 @@ The format of the selector value is:
 
 ```json
 "css selector": {
-      "type":"Dash data type",
+      "type": "Dash data type",
+      "attr": "Use the value of the specified attribute instead of html node text as the basis for transformation",
       "regexp": "PCRE regular expression (no need to enclose in //)",
       "replacement": "Replacement text for each match of 'regexp'",
       "matchpath": "Only files matching this regular expression will be parsed. Will match all files if not set."

--- a/README.md
+++ b/README.md
@@ -150,6 +150,24 @@ The format of the selector value is:
 }
 ```
 
+And you can have multiple transformations specified for the same css selector:
+
+```json
+"css selector": [
+    {
+        "requiretext": "...",
+        "type": "..."
+    },
+    {
+        "requiretext": "...",
+        "type": "..."
+    }
+]
+```
+
+The above allows you to fine tweak nodes selected via css selectors using
+their text contents.
+
 Full documentation on the regular expression format can be found here:
 http://golang.org/pkg/regexp/syntax/
 


### PR DESCRIPTION
1. Add support for getting CSS attribute value.

This commit add a new key 'attr' in dashing.json selector objects.
If `"attr": "attribute"` exists, dashing will get the value of the
"attribute" of the current selected node and use it instead of the
node text as the base name for transforms.

E.g.,

`<a id="wow">link</a>` together with `"attr": "id"` will get "wow"
instead of "link".

2. Add support for requiring text content when matching.

With this commit, we can further require the node selected with
CSS selector to match certain text regexp.

E.g.,

`<h2>This is a title</h2>` with `"requiretext": "^This is"` will
considered as a match, while with `"requiretext": "^No"`, it is not.

3. Add support for multiple transforms of the same CSS selector.
With this commit, we can supply multiple transforms for the same
CSS selector. It enables treating the same CSS selector with
different texts separately.

E.g.,

```html
<h2>Chapter X</h2>
<h2>Section Y</h2>
```

with

```json
"h2": [
  {
    "requiretext": "^Chapter",
    "Type": "Module"
  },
  {
    "requiretext": "^Section",
    "Type": "Section"
  }
]
```
Will treat "X" as Module and "Y" as "Section".