### PR TITLE
Conditionally set VERSION in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION := $(shell git describe --tags)
+VERSION ?= $(shell git describe --tags)
 
 build:
 	go build -o dashing -ldflags "-X main.version=${VERSION}" dashing.go


### PR DESCRIPTION
I am working on packaging Dashing for MacPorts. We build from source, which we obtain from a tarball, not from git; the `make` invocation then fails when trying to define `VERSION`. If the `VERSION` declaration is made conditional with `?=` then we can supply the version as an argument to the `make` invocation.