### PR TITLE
Add install instructions for MacPorts

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,12 @@ For most people, the easiest way is through [Homebrew:](https://brew.sh/)
 brew install dashing
 ```
 
+Or [MacPorts:](https://www.macports.org/)
+
+```
+sudo port install dashing
+```
+
 Prebuilt OSX 64-bit binaries are also available here:
 https://github.com/technosophos/dashing/releases
 


### PR DESCRIPTION
Hi,

This is just a small change which lets people know [this program is installable via MacPorts](https://www.macports.org/ports.php?by=name&substr=dashing) as well as Homebrew. I've transitioned to MacPorts from Homebrew myself and I thought it'd be nice to let fellow MacPorts users know about this. MacPorts still has a significant number of users and is still quite active.

Thanks!