### PR TITLE
github.com/codegangsta/cli has changed to github.com/urfave/cli

### DIFF
--- a/dashing.go
+++ b/dashing.go
@@ -16,7 +16,7 @@ import (
 	"text/template"
 
 	css "github.com/andybalholm/cascadia"
-	"github.com/codegangsta/cli"
+	"github.com/urfave/cli"
 	"golang.org/x/net/html"
 	"golang.org/x/net/html/atom"
 


### PR DESCRIPTION
When I tried building dashing yesterday, I noticed that github.com/codegangsta/cli now redirects to github.com/urfave/cli. 